### PR TITLE
Add OAuth2 token authentication to GitHub API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ enough to get you going. Copy this data to a file and name it something like
 
     net.wagstrom.research.github.projects=pridkett/gitminer
 
+Alternatively, you may authenticate by using an OAuth token to be
+configured as follows in lieu of giving login and password.
+
+    net.wagstrom.research.github.token=YOUROAUTHTOKEN
+
+See http://developer.github.com/v3/oauth/ for more information.
+
 Execution
 ---------
 Execution of GitMiner is a two step process that consists of first using the
@@ -66,6 +73,12 @@ for the tool to function.
 * **name:** `net.wagstrom.research.github.password`<br>
   **default:** no default<br>
   **description:** the companion to `net.wagstrom.research.github.login`.
+  
+* **name:** `net.wagstrom.research.github.token`<br>
+  **default:** no default<br>
+  **description:** this can be set instead of login and password to
+  authenticate with GitHub using the given OAuth token as documented on
+  http://developer.github.com/v3/oauth/.
   
 * **name:** `net.wagstrom.research.github.email`<br>
   **default:** no default<br>

--- a/src/main/java/net/wagstrom/research/github/GitHubMain.java
+++ b/src/main/java/net/wagstrom/research/github/GitHubMain.java
@@ -113,8 +113,13 @@ public class GitHubMain {
         GitHubClient ghc = new GitHubClient();
         String githubUsername = props.getProperty(PropNames.GITHUB_LOGIN, PropDefaults.GITHUB_LOGIN).trim();
         String githubPassword = props.getProperty(PropNames.GITHUB_PASSWORD, PropDefaults.GITHUB_PASSWORD);
-        if (githubUsername.equals("") || githubPassword.equals("")) {
-            log.error("Must set properties {} and {}", PropNames.GITHUB_LOGIN, PropNames.GITHUB_PASSWORD);
+        String githubToken    = props.getProperty(PropNames.GITHUB_TOKEN, PropDefaults.GITHUB_TOKEN).trim();
+        if (!githubUsername.equals("") && !githubPassword.equals("")) {
+            ghc.setCredentials(githubUsername, githubPassword);
+        } else if (!githubToken.equals("")) {
+            ghc.setOAuth2Token(githubToken);
+        } else {
+            log.error("Must set properties {} and {}, or {}", new String[]{PropNames.GITHUB_LOGIN, PropNames.GITHUB_PASSWORD, PropNames.GITHUB_TOKEN});
             log.error("Without these properties you'll be limited to 60 queries and hour, and I'm not going to do that.");
             System.exit(-1);
         }
@@ -124,7 +129,6 @@ public class GitHubMain {
             log.error("GitHub has requested that contact information be included in the user agent field. This address is only used to append to GitMiner user agent.");
             System.exit(-1);
         }
-        ghc.setCredentials(githubUsername, githubPassword);
         ghc.setUserAgent("GitMiner ( version: " + Constants.VERSION + ", https://github.com/pridkett/gitminer, based off egit, user: " + githubUsername + " email: " + email + " )");
 
         connectToGraph(props);

--- a/src/main/java/net/wagstrom/research/github/PropDefaults.java
+++ b/src/main/java/net/wagstrom/research/github/PropDefaults.java
@@ -4,6 +4,7 @@ public class PropDefaults {
     public static final String EMAIL_ADDRESS = "";
     public static final String GITHUB_LOGIN = "";
     public static final String GITHUB_PASSWORD = "";
+    public static final String GITHUB_TOKEN = "";
     
     public static final String GITHUB_PROJECT_NAMES = "";
     public static final String GITHUB_USERNAMES = "";

--- a/src/main/java/net/wagstrom/research/github/PropNames.java
+++ b/src/main/java/net/wagstrom/research/github/PropNames.java
@@ -3,6 +3,7 @@ package net.wagstrom.research.github;
 public class PropNames {
     public static final String GITHUB_LOGIN = "net.wagstrom.research.github.login";
     public static final String GITHUB_PASSWORD = "net.wagstrom.research.github.password";
+    public static final String GITHUB_TOKEN = "net.wagstrom.research.github.token";
     public static final String EMAIL_ADDRESS = "net.wagstrom.research.github.email";
     
     public static final String GITHUB_PROJECT_NAMES = "net.wagstrom.research.github.projects";


### PR DESCRIPTION
Hey Patrick,

wonderful tool – thanks for making it available!

Attached is a small patch to add OAuth2 token support to authenticate w/ GitHub. See http://developer.github.com/v3/#authentication and http://developer.github.com/v3/oauth/#create-a-new-authorization.

Reason I needed this is that OAuth applications may be granted API rate limit increases by GitHub upon request (see http://developer.github.com/v3/#unauthenticated-rate-limited-requests). And of course it's always a good feeling not to have your passwords stored somewhere in plain text.

Cheers,
Niels
